### PR TITLE
Improve timestamp parsing, fix Get-MgGraphAllPage, and optimize result accumulation

### DIFF
--- a/scripts/operational/sync-devices.ps1
+++ b/scripts/operational/sync-devices.ps1
@@ -23,13 +23,21 @@
     Ugur Koc
 
 .VERSION
-    1.0
+    1.1
 
 .CHANGELOG
     1.0 - Initial release
+    1.1 - Improved authentication scopes and fixed group device members search
+        - added `DeviceManagementManagedDevices.PrivilegedOperations.All` scope for interactive Graph auth  
+        - fixed `Get-DevicesByEntraGroup` to correctly match devices by `azureADDeviceId`  
+        - replaced `+=` with `[System.Collections.Generic.List[Object]]` for faster result handling  
+        - standardized string quoting to single quotes  
+        - optimized `Get-MgGraphAllPage` with strongly typed list  
+        - replaced `Out-Null` with `$null =` assignment for cleaner output suppression  
+        - improved consistency in logging and error handling
 
 .LASTUPDATE
-    2025-05-29
+    2025-09-24
 
 .EXAMPLE
     .\sync-devices.ps1 -DeviceNames "LAPTOP001","DESKTOP002"

--- a/scripts/security/get-intune-role-assignments.ps1
+++ b/scripts/security/get-intune-role-assignments.ps1
@@ -249,7 +249,7 @@ try {
     
     # Get all role definitions first
     $roleDefinitionsUri = "https://graph.microsoft.com/v1.0/deviceManagement/roleDefinitions"
-    $roleDefinitions = Get-MgGraphAllPages -Uri $roleDefinitionsUri
+    $roleDefinitions = Get-MgGraphAllPage -Uri $roleDefinitionsUri
     
     Write-Information "✓ Found $($roleDefinitions.Count) role definitions" -InformationAction Continue
     
@@ -262,12 +262,12 @@ try {
     # Get all role assignments directly
     Write-Information "Retrieving role assignments..." -InformationAction Continue
     $roleAssignmentsUri = "https://graph.microsoft.com/v1.0/deviceManagement/roleAssignments"
-    $roleAssignments = Get-MgGraphAllPages -Uri $roleAssignmentsUri
+    $roleAssignments = Get-MgGraphAllPage -Uri $roleAssignmentsUri
     
     Write-Information "✓ Found $($roleAssignments.Count) role assignments" -InformationAction Continue
     
     # Process assignments
-    $allAssignments = @()
+    [System.Collections.Generic.List[Object]]$allAssignments = @()
     $totalAssignments = 0
     $rolesWithAssignments = 0
     $processedRoles = @{}
@@ -310,7 +310,7 @@ try {
             }
         }
         
-        $allAssignments += $assignmentRecord
+        $allAssignments.Add($assignmentRecord)
         $totalAssignments++
     }
     
@@ -394,11 +394,11 @@ try {
         $csvPath = Join-Path $OutputPath "Intune_Role_Assignments_$timestamp.csv"
         
         # Flatten the data for CSV export
-        $csvData = @()
+        [System.Collections.Generic.List[Object]]$csvData = @()
         foreach ($assignment in $allAssignments) {
             if ($assignment.Members.Count -gt 0) {
                 foreach ($member in $assignment.Members) {
-                    $csvData += [PSCustomObject]@{
+                    $csvData.Add([PSCustomObject]@{
                         RoleName       = $assignment.RoleName
                         RoleType       = $assignment.RoleType
                         AssignmentName = $assignment.AssignmentName
@@ -406,11 +406,11 @@ try {
                         MemberEmail    = $member.Email
                         MemberType     = $member.Type
                         Scope          = $assignment.Scope
-                    }
+                    })
                 }
             }
             else {
-                $csvData += [PSCustomObject]@{
+                $csvData.Add([PSCustomObject]@{
                     RoleName       = $assignment.RoleName
                     RoleType       = $assignment.RoleType
                     AssignmentName = $assignment.AssignmentName
@@ -418,7 +418,7 @@ try {
                     MemberEmail    = ""
                     MemberType     = ""
                     Scope          = $assignment.Scope
-                }
+                })
             }
         }
         
@@ -432,7 +432,7 @@ catch {
 }
 finally {
     try {
-        Disconnect-MgGraph | Out-Null
+        $null = Disconnect-MgGraph
         Write-Information "✓ Disconnected from Microsoft Graph" -InformationAction Continue
     }
     catch {


### PR DESCRIPTION
# Pull Request: 
[Security] get-intune-role-assignments.ps1
[Monitoring] get-intune-audit-logs
[Operational] sync-devices.ps1

## 📋 Description

**What does this script do?**
N/A

**Problem/Use Case:**
- Addresses issues with timestamp parsing by implementing checks for
- Fix `Get-MgGraphAllPage` function
- Replace `+=` with `[System.Collections.Generic.List[Object]]` for faster result
- `sync-devices.ps1`:
        - added `DeviceManagementManagedDevices.PrivilegedOperations.All` scope for interactive Graph auth  
        - fixed `Get-DevicesByEntraGroup` to correctly match devices by `azureADDeviceId`  
        - replaced `+=` with `[System.Collections.Generic.List[Object]]` for faster result handling  
        - standardized string quoting to single quotes  
        - optimized `Get-MgGraphAllPage` with strongly typed list  
        - replaced `Out-Null` with `$null =` assignment for cleaner output suppression  
        - improved consistency in logging and error handling
        - 
## ✅ Testing Checklist

- [x] **Lab Testing**: Script has been thoroughly tested in a lab environment
- [x] **Parameter Testing**: All parameter combinations have been tested
- [x] **Error Handling**: Error scenarios have been tested and handled gracefully
- [x] **Permissions**: Script works with minimum required permissions

## 🔄 Breaking Changes

- [x] **No Breaking Changes**: This script doesn't break existing functionality
