### PR TITLE
Fix BadRequest error in get-app-installation-status-report.ps1

### DIFF
--- a/scripts/apps/get-app-installation-status-report.ps1
+++ b/scripts/apps/get-app-installation-status-report.ps1
@@ -318,7 +318,7 @@ try {
 
         try {
             # Get device statuses for this app using the beta endpoint
-            $deviceStatusUri = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps('$($app.id)')/deviceStatuses"
+            $deviceStatusUri = "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$($app.id)/deviceStatuses"
             $deviceStatuses = Get-MgGraphAllPage -Uri $deviceStatusUri
 
             foreach ($status in $deviceStatuses) {


### PR DESCRIPTION
Fixes #11

### Changes
- Removed incorrect OData notation ('id') from device status URI
- Changed `mobileApps('$($app.id)')` to `mobileApps/$($app.id)`
- This resolves the 400 BadRequest errors when retrieving device installation status

### Testing
The script should now successfully retrieve device installation statuses for all managed applications without BadRequest errors.

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/ugurkocde/IntuneAutomation/actions/runs/18845098778) | [View branch](https://github.com/ugurkocde/IntuneAutomation/tree/claude/issue-11-20251027-1446