### PR TITLE
Clarify duplicate device cleanup scope

### DIFF
--- a/mcp/data/scripts-index.json
+++ b/mcp/data/scripts-index.json
@@ -919,9 +919,9 @@
     },
     {
       "id": "cleanup-duplicate-device-records",
-      "title": "Cleanup Duplicate Device Records",
-      "synopsis": "Finds Intune device records that share a serial number and optionally removes the older stale duplicates.",
-      "description": "This script groups all Intune managed devices by serial number and identifies\nduplicates - typically left behind by re-enrollment, OS reinstalls, or Autopilot\nresets. For every duplicate set it keeps the record with the most recent sync and\nmarks the older records for cleanup. By default the script only reports; deletion\nrequires the -Remove switch and is preview-safe via -WhatIf. Removing a device\nrecord from Intune does not wipe the device; it only deletes the stale management\nobject.",
+      "title": "Cleanup Duplicate Intune Device Records",
+      "synopsis": "Finds Intune managed-device records that share a serial number and optionally removes the older stale duplicates.",
+      "description": "This script groups all Intune managed devices by serial number and identifies\nduplicates - typically left behind by re-enrollment, OS reinstalls, or Autopilot\nresets. For every duplicate set it keeps the record with the most recent sync and\nmarks the older records for cleanup. By default the script only reports; deletion\nrequires the -Remove switch and is preview-safe via -WhatIf. Removing a device\nrecord from Intune does not wipe the device; it only deletes the stale management\nobject.\n\nScope is limited to Intune managed-device records returned by\n/deviceManagement/managedDevices. The script does not inspect or delete Microsoft\nEntra device objects or Windows Autopilot registrations. Duplicate-looking Entra\nobjects can be expected with Hybrid Autopilot deployments and must not be treated\nas stale Intune records.",
       "category": "devices",
       "categoryLabel": "devices",
       "tags": [
@@ -934,8 +934,8 @@
       "minRole": "Intune Administrator",
       "platform": "",
       "author": "Ugur Koc",
-      "version": "1.1",
-      "lastUpdate": "2026-07-28",
+      "version": "1.2",
+      "lastUpdate": "2026-07-29",
       "schedule": "",
       "execution": "",
       "output": "",
@@ -969,11 +969,11 @@
         }
       ],
       "examples": [
-        ".\\cleanup-duplicate-device-records.ps1\nReports duplicate device records without deleting anything",
-        ".\\cleanup-duplicate-device-records.ps1 -Remove -WhatIf\nShows exactly which records would be deleted, without deleting them",
-        ".\\cleanup-duplicate-device-records.ps1 -Remove\nDeletes the older duplicate records after an interactive confirmation"
+        ".\\cleanup-duplicate-device-records.ps1\nReports duplicate Intune managed-device records without deleting anything",
+        ".\\cleanup-duplicate-device-records.ps1 -Remove -WhatIf\nShows exactly which Intune managed-device records would be deleted, without deleting them",
+        ".\\cleanup-duplicate-device-records.ps1 -Remove\nDeletes the older duplicate Intune managed-device records after an interactive confirmation"
       ],
-      "notes": "- Requires Microsoft.Graph.Authentication module\n- The newest record per serial number (by lastSyncDateTime, falling back to enrolledDateTime) is always kept\n- Devices with empty or placeholder serial numbers (e.g. \"Defaultstring\") are excluded from duplicate matching\n- Deleting an Intune device record does not wipe or retire the physical device\n- Uses beta Graph endpoints for consistency with the rest of the library\n- Local interactive sign-in uses the MgGraphCommunity module to avoid the Graph SDK's mandatory WAM broker on Windows",
+      "notes": "- Requires Microsoft.Graph.Authentication module\n- Only Intune managed-device records are evaluated\n- Microsoft Entra device objects and Windows Autopilot registrations are never evaluated or deleted\n- Hybrid Autopilot deployments can create expected duplicate-looking Entra device objects\n- The newest record per serial number (by lastSyncDateTime, falling back to enrolledDateTime) is always kept\n- Devices with empty or placeholder serial numbers (e.g. \"Defaultstring\") are excluded from duplicate matching\n- Deleting an Intune device record does not wipe or retire the physical device\n- Uses beta Graph endpoints for consistency with the rest of the library\n- Local interactive sign-in uses the MgGraphCommunity module to avoid the Graph SDK's mandatory WAM broker on Windows",
       "path": "scripts/devices/cleanup-duplicate-device-records.ps1",
       "rawUrl": "https://raw.githubusercontent.com/ugurkocde/intuneautomation/main/scripts/devices/cleanup-duplicate-device-records.ps1",
       "githubUrl": "https://github.com/ugurkocde/intuneautomation/blob/main/scripts/devices/cleanup-duplicate-device-records.ps1"

--- a/scripts/devices/cleanup-duplicate-device-records.ps1
+++ b/scripts/devices/cleanup-duplicate-device-records.ps1
@@ -1,9 +1,9 @@
 <#
 .TITLE
-    Cleanup Duplicate Device Records
+    Cleanup Duplicate Intune Device Records
 
 .SYNOPSIS
-    Finds Intune device records that share a serial number and optionally removes the older stale duplicates.
+    Finds Intune managed-device records that share a serial number and optionally removes the older stale duplicates.
 
 .DESCRIPTION
     This script groups all Intune managed devices by serial number and identifies
@@ -13,6 +13,12 @@
     requires the -Remove switch and is preview-safe via -WhatIf. Removing a device
     record from Intune does not wipe the device; it only deletes the stale management
     object.
+
+    Scope is limited to Intune managed-device records returned by
+    /deviceManagement/managedDevices. The script does not inspect or delete Microsoft
+    Entra device objects or Windows Autopilot registrations. Duplicate-looking Entra
+    objects can be expected with Hybrid Autopilot deployments and must not be treated
+    as stale Intune records.
 
 .TAGS
     Devices,Operational
@@ -27,29 +33,33 @@
     Ugur Koc
 
 .VERSION
-    1.1
+    1.2
 
 .CHANGELOG
+    1.2 - Clarified that only Intune managed-device records are evaluated and removed
     1.1 - Azure Automation now records script progress, outcomes, and summaries in job history
     1.0 - Initial release
 
 .LASTUPDATE
-    2026-07-28
+    2026-07-29
 
 .EXAMPLE
     .\cleanup-duplicate-device-records.ps1
-    Reports duplicate device records without deleting anything
+    Reports duplicate Intune managed-device records without deleting anything
 
 .EXAMPLE
     .\cleanup-duplicate-device-records.ps1 -Remove -WhatIf
-    Shows exactly which records would be deleted, without deleting them
+    Shows exactly which Intune managed-device records would be deleted, without deleting them
 
 .EXAMPLE
     .\cleanup-duplicate-device-records.ps1 -Remove
-    Deletes the older duplicate records after an interactive confirmation
+    Deletes the older duplicate Intune managed-device records after an interactive confirmation
 
 .NOTES
     - Requires Microsoft.Graph.Authentication module
+    - Only Intune managed-device records are evaluated
+    - Microsoft Entra device objects and Windows Autopilot registrations are never evaluated or deleted
+    - Hybrid Autopilot deployments can create expected duplicate-looking Entra device objects
     - The newest record per serial number (by lastSyncDateTime, falling back to enrolledDateTime) is always kept
     - Devices with empty or placeholder serial numbers (e.g. "Defaultstring") are excluded from duplicate matching
     - Deleting an Intune device record does not wipe or retire the physical device
@@ -59,7 +69,7 @@
 
 [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = "High")]
 param(
-    [Parameter(Mandatory = $false, HelpMessage = "Delete the older duplicate records instead of only reporting")]
+    [Parameter(Mandatory = $false, HelpMessage = "Delete the older duplicate Intune managed-device records instead of only reporting")]
     [switch]$Remove,
 
     [Parameter(Mandatory = $false, HelpMessage = "Export results to CSV")]
@@ -224,9 +234,11 @@ function Get-EffectiveTimestamp {
 # ============================================================================
 
 try {
-    Write-Output "Retrieving managed devices..."
+    Write-Output "Scope: Intune managed-device records only."
+    Write-Output "Microsoft Entra device objects and Windows Autopilot registrations are not evaluated or removed."
+    Write-Output "Retrieving Intune managed devices..."
     $devices = Get-MgGraphAllPage -Uri "https://graph.microsoft.com/beta/deviceManagement/managedDevices?`$select=id,deviceName,serialNumber,operatingSystem,model,manufacturer,lastSyncDateTime,enrolledDateTime,userPrincipalName,managementAgent"
-    Write-Output "✓ Found $(@($devices).Count) managed devices"
+    Write-Output "✓ Found $(@($devices).Count) Intune managed devices"
 
     # Placeholder serials would create false duplicate groups
     $invalidSerials = @("", "defaultstring", "tobefilledbyoem", "systemserialnumber", "0", "none", "unknown")
@@ -237,17 +249,17 @@ try {
     $duplicateGroups = @($devicesWithSerial | Group-Object -Property { $_.serialNumber.Trim() } | Where-Object { $_.Count -gt 1 })
 
     if ($duplicateGroups.Count -eq 0) {
-        Write-Output "`nNo duplicate device records found."
+        Write-Output "`nNo duplicate Intune managed-device records found."
         return
     }
 
-    Write-Output "✓ Found $($duplicateGroups.Count) serial number(s) with duplicate records"
+    Write-Output "✓ Found $($duplicateGroups.Count) serial number(s) with duplicate Intune managed-device records"
 
     [System.Collections.Generic.List[Object]]$report = @()
     $deleted = 0
     $deleteFailed = 0
 
-    Write-Output "`nDUPLICATE DEVICE RECORDS"
+    Write-Output "`nDUPLICATE INTUNE MANAGED-DEVICE RECORDS"
     Write-Output ("=" * 50)
 
     foreach ($group in $duplicateGroups) {
@@ -298,7 +310,7 @@ try {
     $totalStale = $report.Count
     Write-Output "`n"
     Write-Output ("=" * 50)
-    Write-Output "Summary: $($duplicateGroups.Count) duplicate serials, $totalStale stale records"
+    Write-Output "Summary: $($duplicateGroups.Count) duplicate serials, $totalStale stale Intune managed-device records"
     if ($Remove) {
         Write-Output "Deleted: $deleted | Failed: $deleteFailed"
     }


### PR DESCRIPTION
## What changed

- Renamed the displayed script title to clarify that it handles Intune device records.
- Added explicit documentation and runtime messages stating that Microsoft Entra device objects and Windows Autopilot registrations are outside the script scope.
- Added a Hybrid Autopilot safety warning.
- Updated examples, parameter help, and summary messages.
- Bumped the script from version 1.1 to 1.2 and regenerated the MCP catalog entry.

## Why

The script queries only `/deviceManagement/managedDevices`, but its previous wording could imply that it also finds duplicate Microsoft Entra device objects. Hybrid Autopilot deployments can legitimately create two Entra objects for one physical device. Treating the Autopilot anchor as a stale Intune record could cause provisioning failures.

## Impact

The Graph query and deletion behavior are unchanged. Administrators now see the scope and safety boundary before reviewing or removing records.

## Validation

- PowerShell parser passed
- PSScriptAnalyzer passed with the repository rule exclusions
- MCP catalog verification passed, 38 tests
- Git diff whitespace validation passed