### PR TITLE
Stop caching 404s for script pages when the GitHub catalog fetch fails

### DIFF
--- a/web/src/app/script/[slug]/error.tsx
+++ b/web/src/app/script/[slug]/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+import { Button } from "~/components/ui/button";
+
+// Rendered when the script catalog cannot be loaded (for example a GitHub API
+// outage). Next.js serves this with a 500 that is never cached, so the page
+// recovers on the next request instead of serving a stale 404.
+export default function ScriptError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Script page failed to render:", error);
+  }, [error]);
+
+  return (
+    <main className="container mx-auto flex min-h-[60vh] max-w-2xl flex-col items-center justify-center px-4 py-16 text-center">
+      <h1 className="text-2xl font-semibold tracking-tight">
+        This script could not be loaded right now
+      </h1>
+      <p className="text-muted-foreground mt-3">
+        The script library is temporarily unavailable. The script has not been
+        removed. Please try again in a moment.
+      </p>
+      <div className="mt-8 flex gap-3">
+        <Button onClick={() => reset()}>Try again</Button>
+        <Button asChild variant="outline">
+          <Link href="/scripts/">Browse all scripts</Link>
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/web/src/app/script/[slug]/page.tsx
+++ b/web/src/app/script/[slug]/page.tsx
@@ -13,108 +13,116 @@ interface PageProps {
   params: Promise<{ slug: string }>;
 }
 
+// Support both slug and ID for backward compatibility with older links.
+function findScript(scripts: Script[], slug: string): Script | undefined {
+  return scripts.find((s) => s.slug === slug || s.id === slug);
+}
+
 // This function generates metadata for each script page
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const { slug } = await params;
 
+  let scripts: Script[];
   try {
-    // Get all scripts to find the matching one
-    const scripts = await githubService.fetchAllScripts();
-    const script = scripts.find(
-      (s: Script) => s.slug === slug || s.id === slug, // Support both slug and ID for backward compatibility
-    );
-
-    if (!script) {
-      return {
-        title: "Script Not Found",
-        description: "The requested script could not be found.",
-        robots: { index: false, follow: false },
-      };
-    }
-
-    return {
-      // Short title — root layout's title template appends "| IntuneAutomation".
-      title: script.title,
-      description:
-        script.description ||
-        `PowerShell script for ${script.title}. Automate Microsoft Intune tasks efficiently.`,
-      keywords: [
-        "Microsoft Intune",
-        "PowerShell",
-        "Automation",
-        "Script",
-        script.title,
-        ...script.tags,
-      ].join(", "),
-      openGraph: {
-        title: `${script.title} | IntuneAutomation`,
-        description:
-          script.description || `PowerShell script for ${script.title}`,
-        type: "article",
-        url: `https://intuneautomation.com/script/${slug}/`,
-        siteName: "IntuneAutomation",
-      },
-      twitter: {
-        card: "summary",
-        title: `${script.title} | IntuneAutomation`,
-        description:
-          script.description || `PowerShell script for ${script.title}`,
-      },
-      alternates: {
-        canonical: `/script/${slug}/`,
-      },
-    };
+    scripts = await githubService.fetchAllScripts();
   } catch (error) {
+    console.error(
+      `Error loading catalog for metadata of /script/${slug}:`,
+      error,
+    );
     return {
       title: "Error Loading Script",
       description: "An error occurred while loading the script.",
       robots: { index: false, follow: false },
     };
   }
+
+  const script = findScript(scripts, slug);
+  if (!script) {
+    return {
+      title: "Script Not Found",
+      description: "The requested script could not be found.",
+      robots: { index: false, follow: false },
+    };
+  }
+
+  return {
+    // Short title — root layout's title template appends "| IntuneAutomation".
+    title: script.title,
+    description:
+      script.description ||
+      `PowerShell script for ${script.title}. Automate Microsoft Intune tasks efficiently.`,
+    keywords: [
+      "Microsoft Intune",
+      "PowerShell",
+      "Automation",
+      "Script",
+      script.title,
+      ...script.tags,
+    ].join(", "),
+    openGraph: {
+      title: `${script.title} | IntuneAutomation`,
+      description:
+        script.description || `PowerShell script for ${script.title}`,
+      type: "article",
+      url: `https://intuneautomation.com/script/${slug}/`,
+      siteName: "IntuneAutomation",
+    },
+    twitter: {
+      card: "summary",
+      title: `${script.title} | IntuneAutomation`,
+      description:
+        script.description || `PowerShell script for ${script.title}`,
+    },
+    alternates: {
+      canonical: `/script/${slug}/`,
+    },
+  };
 }
 
 export default async function ScriptPage({ params }: PageProps) {
   const { slug } = await params;
 
-  try {
-    const [scripts, permissionsData] = await Promise.all([
-      githubService.fetchAllScripts(),
-      githubService.fetchPermissionsData(),
-    ]);
+  // No blanket try/catch here on purpose. If the catalog cannot be loaded,
+  // fetchAllScripts throws and Next.js renders error.tsx with an uncached 500.
+  // Wrapping that in notFound() would let ISR cache a 404 for every script
+  // requested during a transient GitHub outage.
+  const [scripts, permissionsData] = await Promise.all([
+    githubService.fetchAllScripts(),
+    githubService.fetchPermissionsData(),
+  ]);
 
-    const script = scripts.find(
-      (s: Script) => s.slug === slug || s.id === slug, // Support both slug and ID for backward compatibility
-    );
+  if (scripts.length === 0) {
+    throw new Error("Script catalog is empty; refusing to render a 404");
+  }
 
-    if (!script) {
-      notFound();
-    }
-
-    const scriptUrl = `https://intuneautomation.com/script/${slug}/`;
-    const breadcrumbItems = [
-      { name: "Home", url: "https://intuneautomation.com/" },
-      { name: "Scripts", url: "https://intuneautomation.com/scripts/" },
-      { name: script.title },
-    ];
-
-    // Pass script data and permissions as JSON to avoid serialization issues
-    return (
-      <>
-        <ScriptStructuredData script={script} url={scriptUrl} />
-        <ScriptFAQStructuredData script={script} />
-        <BreadcrumbStructuredData items={breadcrumbItems} />
-        <ScriptDetailPageWrapper
-          script={JSON.parse(JSON.stringify(script))}
-          allScripts={JSON.parse(JSON.stringify(scripts))}
-          permissionsData={JSON.parse(JSON.stringify(permissionsData))}
-        />
-      </>
-    );
-  } catch (error) {
+  const script = findScript(scripts, slug);
+  if (!script) {
     notFound();
   }
+
+  const scriptUrl = `https://intuneautomation.com/script/${slug}/`;
+  const breadcrumbItems = [
+    { name: "Home", url: "https://intuneautomation.com/" },
+    { name: "Scripts", url: "https://intuneautomation.com/scripts/" },
+    { name: script.title },
+  ];
+
+  // Pass script data and permissions as JSON to avoid serialization issues
+  return (
+    <>
+      <ScriptStructuredData script={script} url={scriptUrl} />
+      <ScriptFAQStructuredData script={script} />
+      <BreadcrumbStructuredData items={breadcrumbItems} />
+      <ScriptDetailPageWrapper
+        script={JSON.parse(JSON.stringify(script))}
+        allScripts={JSON.parse(JSON.stringify(scripts))}
+        permissionsData={JSON.parse(JSON.stringify(permissionsData))}
+      />
+    </>
+  );
 }
 
 // Generate static paths for better SEO (optional, for most popular scripts)

--- a/web/src/app/stats/page.tsx
+++ b/web/src/app/stats/page.tsx
@@ -38,7 +38,12 @@ export default async function StatsPage() {
   const [monthly, analyticsMap, scripts] = await Promise.all([
     AnalyticsService.getMonthlyAnalytics(12),
     AnalyticsService.getAllScriptAnalytics(),
-    githubService.fetchAllScripts(),
+    // fetchAllScripts throws when GitHub is unreachable; this page can still
+    // render from analytics alone, so degrade to an empty list here.
+    githubService.fetchAllScripts().catch((error: unknown) => {
+      console.error("Error fetching scripts for stats page:", error);
+      return [];
+    }),
   ]);
 
   const scriptById = new Map(scripts.map((s) => [s.id, s]));

--- a/web/src/lib/fetch-resilience.ts
+++ b/web/src/lib/fetch-resilience.ts
@@ -1,0 +1,94 @@
+// Small, dependency-free helpers that make upstream fetches (GitHub API, raw
+// content) tolerant of transient failures. Kept separate from github.ts so they
+// can be unit tested without pulling in env validation.
+
+export interface RetryOptions {
+  /** Total attempts including the first one. */
+  attempts?: number;
+  /** Base delay in ms; attempt n waits baseDelayMs * 2^(n-1). */
+  baseDelayMs?: number;
+  /** Decide whether a non-ok response should be retried. */
+  isRetryable?: (response: Response) => boolean;
+  /** Injected for tests. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * 429 and 5xx are transient. GitHub also reports primary and secondary rate
+ * limits as 403, distinguishable from a real permission error by the
+ * x-ratelimit-remaining or retry-after headers. Other 4xx are not retried.
+ */
+export function isRetryableResponse(response: Response): boolean {
+  const { status, headers } = response;
+  if (status === 429 || (status >= 500 && status <= 599)) return true;
+  if (status === 403) {
+    return (
+      headers.get("x-ratelimit-remaining") === "0" || headers.has("retry-after")
+    );
+  }
+  return false;
+}
+
+/**
+ * Runs fetchFn until it returns an ok response or a non-retryable status.
+ * Network errors (fetchFn throwing) are retried. The last response or error
+ * is surfaced to the caller once attempts are exhausted.
+ */
+export async function fetchWithRetry(
+  fetchFn: () => Promise<Response>,
+  options: RetryOptions = {},
+): Promise<Response> {
+  const attempts = Math.max(1, options.attempts ?? 3);
+  const baseDelayMs = options.baseDelayMs ?? 250;
+  const retryable = options.isRetryable ?? isRetryableResponse;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      const response = await fetchFn();
+      if (response.ok || !retryable(response) || attempt === attempts) {
+        return response;
+      }
+    } catch (error) {
+      lastError = error;
+      if (attempt === attempts) {
+        throw error;
+      }
+    }
+    await sleep(baseDelayMs * 2 ** (attempt - 1));
+  }
+
+  // Unreachable: the loop either returns or throws on the final attempt.
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("fetchWithRetry exhausted attempts");
+}
+
+/**
+ * Maps items with at most `limit` tasks in flight. Preserves input order and
+ * fails fast: the first rejection rejects the whole call.
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array<R>(items.length);
+  const workers = Math.max(1, Math.min(limit, items.length));
+  let next = 0;
+
+  const run = async () => {
+    while (true) {
+      const index = next++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index] as T, index);
+    }
+  };
+
+  await Promise.all(Array.from({ length: workers }, run));
+  return results;
+}

--- a/web/src/lib/github.ts
+++ b/web/src/lib/github.ts
@@ -10,6 +10,7 @@ import type {
 } from "./scripts";
 import { generateSlug, ensureUniqueSlug } from "./scripts";
 import { AnalyticsService } from "./supabase-analytics";
+import { fetchWithRetry, mapWithConcurrency } from "./fetch-resilience";
 
 interface GitHubFile {
   name: string;
@@ -48,6 +49,17 @@ const STRUCTURED_TEST_RESULTS_URL =
 const PERMISSIONS_URL =
   "https://raw.githubusercontent.com/ugurkocde/IntuneAutomation/refs/heads/main/permissions.json";
 
+// How many script files to download from GitHub at the same time. High enough
+// to keep a cold render fast, low enough to stay clear of secondary rate limits.
+const SCRIPT_FETCH_CONCURRENCY = 8;
+
+/**
+ * Last complete catalog this server instance produced. If GitHub becomes
+ * unreachable after a successful fetch, callers keep serving this snapshot
+ * instead of an empty list that pages would misread as "script not found".
+ */
+let lastKnownGoodScripts: Script[] | null = null;
+
 class GitHubService {
   private token: string;
 
@@ -56,18 +68,22 @@ class GitHubService {
   }
 
   private async fetchWithAuth(url: string): Promise<Response> {
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${this.token}`,
-        Accept: "application/vnd.github.v3+json",
-        "User-Agent": "IntuneAutomation-Website",
-      },
-      next: { revalidate: 300 }, // Cache for 5 minutes
-    });
+    // Transient GitHub failures (429, 5xx, dropped connections) are retried
+    // with backoff so a single hiccup does not fail the whole catalog fetch.
+    const response = await fetchWithRetry(() =>
+      fetch(url, {
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          Accept: "application/vnd.github.v3+json",
+          "User-Agent": "IntuneAutomation-Website",
+        },
+        next: { revalidate: 300 }, // Cache for 5 minutes
+      }),
+    );
 
     if (!response.ok) {
       throw new Error(
-        `GitHub API error: ${response.status} ${response.statusText}`,
+        `GitHub API error: ${response.status} ${response.statusText} (${url})`,
       );
     }
 
@@ -95,23 +111,21 @@ class GitHubService {
   async getAllScriptFiles(): Promise<GitHubFile[]> {
     const allFiles: GitHubFile[] = [];
 
+    // Directory listing errors propagate on purpose: a partial file list would
+    // make the missing scripts look deleted rather than temporarily unavailable.
     const processDirectory = async (path: string): Promise<void> => {
-      try {
-        const files = await this.getRepositoryFiles(path);
+      const files = await this.getRepositoryFiles(path);
 
-        for (const file of files) {
-          if (
-            file.type === "file" &&
-            (file.name.endsWith(".ps1") || file.name.endsWith(".sh"))
-          ) {
-            allFiles.push(file);
-          } else if (file.type === "dir") {
-            // Recursively process subdirectories
-            await processDirectory(file.path);
-          }
+      for (const file of files) {
+        if (
+          file.type === "file" &&
+          (file.name.endsWith(".ps1") || file.name.endsWith(".sh"))
+        ) {
+          allFiles.push(file);
+        } else if (file.type === "dir") {
+          // Recursively process subdirectories
+          await processDirectory(file.path);
         }
-      } catch (error) {
-        console.warn(`Failed to process directory ${path}:`, error);
       }
     };
 
@@ -416,188 +430,213 @@ class GitHubService {
     };
   }
 
+  /**
+   * Loads the full script catalog from GitHub.
+   *
+   * Throws when the catalog cannot be assembled completely and no earlier
+   * snapshot exists on this instance. Callers that render a specific script
+   * must let that error propagate (Next.js returns an uncached 500) instead of
+   * treating it as "not found", which ISR would otherwise cache as a 404.
+   */
   async fetchAllScripts(): Promise<Script[]> {
     try {
-      const [files, testResults, structuredTests, analyticsData] =
-        await Promise.all([
-          this.getAllScriptFiles(),
-          this.fetchTestResults(),
-          this.fetchStructuredTestResults(),
-          AnalyticsService.getAllScriptAnalytics(),
-        ]);
-
-      const scripts: Script[] = [];
-      const remediationScripts = new Map<
-        string,
-        { detection?: Script; remediation?: Script }
-      >();
-      const existingSlugs: string[] = [];
-
-      for (const file of files) {
-        try {
-          const content = await this.getFileContent(file.path);
-          const fileExtension = file.name.endsWith(".ps1") ? ".ps1" : ".sh";
-          const metadata = this.parseScriptMetadata(content, fileExtension);
-
-          // Generate ID from filename
-          const id = file.name.replace(/\.(ps1|sh)$/, "");
-
-          // Find matching test result
-          const testResult = testResults.find(
-            (result) =>
-              result.filename === file.name || result.filename === id + ".ps1",
-          );
-
-          // Structured per-tier tests
-          const tests = structuredTests[file.name];
-
-          // Get analytics data for this script, fallback to mock data if not available
-          const analytics = analyticsData[id];
-          const usageStats: ScriptUsageStats = analytics
-            ? {
-                totalViews: analytics.total_views,
-                totalDownloads: analytics.total_downloads,
-                totalDeployments: analytics.total_deployments,
-                weeklyViews: analytics.weekly_views,
-                weeklyDownloads: analytics.weekly_downloads,
-                weeklyDeployments: analytics.weekly_deployments,
-                lastViewedAt: analytics.last_viewed_at,
-              }
-            : this.generateMockUsageStats(id);
-
-          // Determine script type
-          const isRemediationScript = file.path.includes(
-            "scripts/remediation/",
-          );
-          const scriptType: ScriptType = isRemediationScript
-            ? "remediation"
-            : "standalone";
-
-          // Generate title and slug
-          const title =
-            metadata.title ||
-            file.name.replace(/\.(ps1|sh)$/, "").replace(/-/g, " ");
-          const baseSlug = generateSlug(title);
-          const slug = ensureUniqueSlug(baseSlug, existingSlugs);
-          existingSlugs.push(slug);
-
-          // Create script object with defaults
-          const script: Script = {
-            id,
-            slug,
-            title,
-            description: metadata.description || "No description available",
-            code: content,
-            tags:
-              metadata.tags ||
-              (isRemediationScript ? ["Remediation"] : ["Configuration"]),
-            lastUpdated: metadata.lastUpdated,
-            minRole: metadata.minRole,
-            testedPlatforms: metadata.testedPlatforms,
-            author: metadata.author,
-            version: metadata.version,
-            permissions: metadata.permissions,
-            example: metadata.example,
-            notes: metadata.notes,
-            changelog: metadata.changelog,
-            githubPath: file.path,
-            githubUrl: file.html_url,
-            testResult: testResult,
-            tests: tests,
-            usageStats: usageStats,
-            scriptType: scriptType,
-            pairScript: metadata.pairScript,
-            remediationType: metadata.remediationType,
-          };
-
-          // Handle remediation scripts separately
-          if (isRemediationScript && metadata.remediationType) {
-            // Extract folder name from path (e.g., "antivirus-definition-updates")
-            const pathParts = file.path.split("/");
-            const folderName = pathParts[pathParts.length - 2];
-
-            if (folderName && !remediationScripts.has(folderName)) {
-              remediationScripts.set(folderName, {});
-            }
-
-            const remediationGroup = folderName
-              ? remediationScripts.get(folderName)!
-              : null;
-            if (!remediationGroup) continue;
-            if (metadata.remediationType === "Detection") {
-              remediationGroup.detection = script;
-            } else if (metadata.remediationType === "Remediation") {
-              remediationGroup.remediation = script;
-            }
-          } else {
-            // Regular standalone script
-            scripts.push(script);
-          }
-        } catch (error) {
-          console.warn(`Failed to process script ${file.name}:`, error);
-        }
-      }
-
-      // Process remediation scripts and create combined entries
-      for (const [folderName, pair] of remediationScripts.entries()) {
-        if (pair.detection && pair.remediation) {
-          // Create a combined remediation script entry
-          const remediationTitle = pair.detection.title.replace(
-            " Detection",
-            "",
-          );
-          const remediationSlug = ensureUniqueSlug(
-            generateSlug(remediationTitle),
-            existingSlugs,
-          );
-          existingSlugs.push(remediationSlug);
-
-          const remediationScript: Script = {
-            id: folderName,
-            slug: remediationSlug,
-            title: remediationTitle,
-            description: pair.detection.description,
-            code: pair.detection.code, // Default to detection code
-            tags: [
-              "Remediation",
-              ...pair.detection.tags.filter((t) => t !== "Remediation"),
-            ],
-            lastUpdated:
-              pair.detection.lastUpdated || pair.remediation.lastUpdated,
-            minRole: pair.detection.minRole,
-            testedPlatforms: pair.detection.testedPlatforms,
-            author: pair.detection.author,
-            version: pair.detection.version,
-            permissions: pair.detection.permissions,
-            example: pair.detection.example,
-            notes: pair.detection.notes,
-            changelog: pair.detection.changelog,
-            githubPath: `scripts/remediation/${folderName}`,
-            githubUrl: `https://github.com/${REPO_OWNER}/${REPO_NAME}/tree/main/scripts/remediation/${folderName}`,
-            testResult: pair.detection.testResult,
-            tests: pair.detection.tests,
-            usageStats: pair.detection.usageStats,
-            scriptType: "remediation",
-            category: "remediation",
-            remediationPair: {
-              detection: pair.detection,
-              remediation: pair.remediation,
-            },
-          };
-
-          scripts.push(remediationScript);
-        } else {
-          // If we don't have both scripts, add them individually
-          if (pair.detection) scripts.push(pair.detection);
-          if (pair.remediation) scripts.push(pair.remediation);
-        }
-      }
-
+      const scripts = await this.buildScriptCatalog();
+      lastKnownGoodScripts = scripts;
       return scripts;
     } catch (error) {
       console.error("Failed to fetch scripts from GitHub:", error);
-      return [];
+      if (lastKnownGoodScripts) {
+        console.warn(
+          `Serving last known good catalog (${lastKnownGoodScripts.length} scripts)`,
+        );
+        return lastKnownGoodScripts;
+      }
+      throw error instanceof Error
+        ? error
+        : new Error("Failed to fetch scripts from GitHub");
     }
+  }
+
+  private async buildScriptCatalog(): Promise<Script[]> {
+    const [files, testResults, structuredTests, analyticsData] =
+      await Promise.all([
+        this.getAllScriptFiles(),
+        this.fetchTestResults(),
+        this.fetchStructuredTestResults(),
+        AnalyticsService.getAllScriptAnalytics(),
+      ]);
+
+    if (files.length === 0) {
+      throw new Error("GitHub returned no script files");
+    }
+
+    // Download file contents in parallel. Any single failure rejects the
+    // whole catalog: an incomplete list would 404 the scripts it is missing.
+    const contents = await mapWithConcurrency(
+      files,
+      SCRIPT_FETCH_CONCURRENCY,
+      (file) => this.getFileContent(file.path),
+    );
+
+    const scripts: Script[] = [];
+    const remediationScripts = new Map<
+      string,
+      { detection?: Script; remediation?: Script }
+    >();
+    const existingSlugs: string[] = [];
+
+    for (const [index, file] of files.entries()) {
+      const content = contents[index] as string;
+      const fileExtension = file.name.endsWith(".ps1") ? ".ps1" : ".sh";
+      const metadata = this.parseScriptMetadata(content, fileExtension);
+
+      // Generate ID from filename
+      const id = file.name.replace(/\.(ps1|sh)$/, "");
+
+      // Find matching test result
+      const testResult = testResults.find(
+        (result) =>
+          result.filename === file.name || result.filename === id + ".ps1",
+      );
+
+      // Structured per-tier tests
+      const tests = structuredTests[file.name];
+
+      // Get analytics data for this script, fallback to mock data if not available
+      const analytics = analyticsData[id];
+      const usageStats: ScriptUsageStats = analytics
+        ? {
+            totalViews: analytics.total_views,
+            totalDownloads: analytics.total_downloads,
+            totalDeployments: analytics.total_deployments,
+            weeklyViews: analytics.weekly_views,
+            weeklyDownloads: analytics.weekly_downloads,
+            weeklyDeployments: analytics.weekly_deployments,
+            lastViewedAt: analytics.last_viewed_at,
+          }
+        : this.generateMockUsageStats(id);
+
+      // Determine script type
+      const isRemediationScript = file.path.includes("scripts/remediation/");
+      const scriptType: ScriptType = isRemediationScript
+        ? "remediation"
+        : "standalone";
+
+      // Generate title and slug
+      const title =
+        metadata.title ||
+        file.name.replace(/\.(ps1|sh)$/, "").replace(/-/g, " ");
+      const baseSlug = generateSlug(title);
+      const slug = ensureUniqueSlug(baseSlug, existingSlugs);
+      existingSlugs.push(slug);
+
+      // Create script object with defaults
+      const script: Script = {
+        id,
+        slug,
+        title,
+        description: metadata.description || "No description available",
+        code: content,
+        tags:
+          metadata.tags ||
+          (isRemediationScript ? ["Remediation"] : ["Configuration"]),
+        lastUpdated: metadata.lastUpdated,
+        minRole: metadata.minRole,
+        testedPlatforms: metadata.testedPlatforms,
+        author: metadata.author,
+        version: metadata.version,
+        permissions: metadata.permissions,
+        example: metadata.example,
+        notes: metadata.notes,
+        changelog: metadata.changelog,
+        githubPath: file.path,
+        githubUrl: file.html_url,
+        testResult: testResult,
+        tests: tests,
+        usageStats: usageStats,
+        scriptType: scriptType,
+        pairScript: metadata.pairScript,
+        remediationType: metadata.remediationType,
+      };
+
+      // Handle remediation scripts separately
+      if (isRemediationScript && metadata.remediationType) {
+        // Extract folder name from path (e.g., "antivirus-definition-updates")
+        const pathParts = file.path.split("/");
+        const folderName = pathParts[pathParts.length - 2];
+
+        if (folderName && !remediationScripts.has(folderName)) {
+          remediationScripts.set(folderName, {});
+        }
+
+        const remediationGroup = folderName
+          ? remediationScripts.get(folderName)!
+          : null;
+        if (!remediationGroup) continue;
+        if (metadata.remediationType === "Detection") {
+          remediationGroup.detection = script;
+        } else if (metadata.remediationType === "Remediation") {
+          remediationGroup.remediation = script;
+        }
+      } else {
+        // Regular standalone script
+        scripts.push(script);
+      }
+    }
+
+    // Process remediation scripts and create combined entries
+    for (const [folderName, pair] of remediationScripts.entries()) {
+      if (pair.detection && pair.remediation) {
+        // Create a combined remediation script entry
+        const remediationTitle = pair.detection.title.replace(" Detection", "");
+        const remediationSlug = ensureUniqueSlug(
+          generateSlug(remediationTitle),
+          existingSlugs,
+        );
+        existingSlugs.push(remediationSlug);
+
+        const remediationScript: Script = {
+          id: folderName,
+          slug: remediationSlug,
+          title: remediationTitle,
+          description: pair.detection.description,
+          code: pair.detection.code, // Default to detection code
+          tags: [
+            "Remediation",
+            ...pair.detection.tags.filter((t) => t !== "Remediation"),
+          ],
+          lastUpdated:
+            pair.detection.lastUpdated || pair.remediation.lastUpdated,
+          minRole: pair.detection.minRole,
+          testedPlatforms: pair.detection.testedPlatforms,
+          author: pair.detection.author,
+          version: pair.detection.version,
+          permissions: pair.detection.permissions,
+          example: pair.detection.example,
+          notes: pair.detection.notes,
+          changelog: pair.detection.changelog,
+          githubPath: `scripts/remediation/${folderName}`,
+          githubUrl: `https://github.com/${REPO_OWNER}/${REPO_NAME}/tree/main/scripts/remediation/${folderName}`,
+          testResult: pair.detection.testResult,
+          tests: pair.detection.tests,
+          usageStats: pair.detection.usageStats,
+          scriptType: "remediation",
+          category: "remediation",
+          remediationPair: {
+            detection: pair.detection,
+            remediation: pair.remediation,
+          },
+        };
+
+        scripts.push(remediationScript);
+      } else {
+        // If we don't have both scripts, add them individually
+        if (pair.detection) scripts.push(pair.detection);
+        if (pair.remediation) scripts.push(pair.remediation);
+      }
+    }
+
+    return scripts;
   }
 }
 

--- a/web/tests/fetchResilience.test.mjs
+++ b/web/tests/fetchResilience.test.mjs
@@ -1,0 +1,142 @@
+// @ts-nocheck -- Node's test runner executes TypeScript imports directly.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  fetchWithRetry,
+  isRetryableResponse,
+  mapWithConcurrency,
+} from "../src/lib/fetch-resilience.ts";
+
+const noSleep = async () => {};
+const response = (status, headers = {}) =>
+  new Response(null, { status, headers });
+
+test("isRetryableResponse treats 429 and 5xx as transient", () => {
+  assert.equal(isRetryableResponse(response(429)), true);
+  assert.equal(isRetryableResponse(response(502)), true);
+  assert.equal(isRetryableResponse(response(404)), false);
+  assert.equal(isRetryableResponse(response(401)), false);
+});
+
+test("isRetryableResponse retries GitHub rate-limit 403s but not permission 403s", () => {
+  assert.equal(isRetryableResponse(response(403)), false);
+  assert.equal(
+    isRetryableResponse(response(403, { "x-ratelimit-remaining": "0" })),
+    true,
+  );
+  assert.equal(
+    isRetryableResponse(response(403, { "retry-after": "30" })),
+    true,
+  );
+  assert.equal(
+    isRetryableResponse(response(403, { "x-ratelimit-remaining": "42" })),
+    false,
+  );
+});
+
+test("fetchWithRetry returns the first ok response without retrying", async () => {
+  let calls = 0;
+  const res = await fetchWithRetry(
+    async () => {
+      calls++;
+      return response(200);
+    },
+    { sleep: noSleep },
+  );
+  assert.equal(res.status, 200);
+  assert.equal(calls, 1);
+});
+
+test("fetchWithRetry retries transient statuses and network errors", async () => {
+  const outcomes = [
+    () => Promise.reject(new Error("ECONNRESET")),
+    () => Promise.resolve(response(503)),
+    () => Promise.resolve(response(200)),
+  ];
+  let calls = 0;
+  const res = await fetchWithRetry(() => outcomes[calls++](), {
+    attempts: 3,
+    sleep: noSleep,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(calls, 3);
+});
+
+test("fetchWithRetry does not retry non-transient statuses", async () => {
+  let calls = 0;
+  const res = await fetchWithRetry(
+    async () => {
+      calls++;
+      return response(404);
+    },
+    { attempts: 3, sleep: noSleep },
+  );
+  assert.equal(res.status, 404);
+  assert.equal(calls, 1);
+});
+
+test("fetchWithRetry surfaces the last failure once attempts are exhausted", async () => {
+  let calls = 0;
+  const res = await fetchWithRetry(
+    async () => {
+      calls++;
+      return response(500);
+    },
+    { attempts: 2, sleep: noSleep },
+  );
+  assert.equal(res.status, 500);
+  assert.equal(calls, 2);
+
+  await assert.rejects(
+    fetchWithRetry(
+      async () => {
+        throw new Error("down");
+      },
+      { attempts: 2, sleep: noSleep },
+    ),
+    /down/,
+  );
+});
+
+test("fetchWithRetry backs off exponentially between attempts", async () => {
+  const waits = [];
+  let calls = 0;
+  await fetchWithRetry(
+    async () => {
+      calls++;
+      return response(calls < 3 ? 500 : 200);
+    },
+    { attempts: 3, baseDelayMs: 100, sleep: async (ms) => void waits.push(ms) },
+  );
+  assert.deepEqual(waits, [100, 200]);
+});
+
+test("mapWithConcurrency preserves order and caps in-flight work", async () => {
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const items = [5, 1, 4, 2, 3, 0];
+  const result = await mapWithConcurrency(items, 2, async (n) => {
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    await new Promise((r) => setTimeout(r, n));
+    inFlight--;
+    return n * 10;
+  });
+  assert.deepEqual(result, [50, 10, 40, 20, 30, 0]);
+  assert.equal(maxInFlight, 2);
+});
+
+test("mapWithConcurrency rejects when any task fails", async () => {
+  await assert.rejects(
+    mapWithConcurrency([1, 2, 3], 3, async (n) => {
+      if (n === 2) throw new Error("boom");
+      return n;
+    }),
+    /boom/,
+  );
+});
+
+test("mapWithConcurrency handles empty input", async () => {
+  assert.deepEqual(await mapWithConcurrency([], 4, async (x) => x), []);
+});


### PR DESCRIPTION
### Problem
Every script detail page returned 404 for several minutes after the last production deployment. The page wrapped its render in a try/catch that called notFound() on any error, and fetchAllScripts returned an empty list when GitHub failed. Incremental Static Regeneration then cached those 404s for the 300 second revalidate window, so a transient upstream hiccup looked like every script had been deleted.

### Changes
- fetchAllScripts throws when the catalog cannot be assembled and serves the last complete catalog this instance produced if one exists
- Directory listing and per-file failures propagate instead of producing a partial catalog
- GitHub requests retry transient failures (429, 5xx, rate-limit 403, dropped connections) with exponential backoff
- Script contents download in parallel with a concurrency limit of 8
- The script page calls notFound() only when the catalog loaded and lacks the slug or legacy id; catalog errors render a new error boundary as an uncached 500 with a retry button
- The stats page catches a failed catalog fetch explicitly since it can render from analytics alone
- All other consumers (sitemap, scripts listing, pillar page, API route, generateStaticParams) already caught errors and were verified unchanged

### Verification
- Unit tests for the retry and concurrency helpers pass (10 tests)
- Local dev server with an invalid GitHub token: script page returns 500 and the error boundary renders in headless Chrome, no 404
- Local dev server with a valid token: real slug 200, legacy id 200, unknown slug 404
- TypeScript check reports no errors in changed files (pre-existing errors in the MCP server module are unrelated)